### PR TITLE
Lockscreen charging info : real time values

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -76,3 +76,6 @@ RECOVERY_FSTAB_VERSION := 2
 # Selinux
 BOARD_SEPOLICY_DIRS += \
     device/samsung/n7100/selinux
+
+#Lockscreen charging info : real time values for current and voltage
+BOARD_GLOBAL_CFLAGS += -DBATTERY_REAL_INFO


### PR DESCRIPTION
Use current_now and voltage_now instead current_max and voltage_max.

reference: 
https://github.com/ResurrectionRemix/system_core/commits/nougat 
FEB 18,2017 commit
5c0fc72c13f31d2d439cd843268277f414befad6